### PR TITLE
:bug: refactor: substitui a geração de nomes de arquivos para upload …

### DIFF
--- a/src/controllers/receitaController.ts
+++ b/src/controllers/receitaController.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 import { PrismaTemaRepository } from '../repositories/prisma/PrismaTemaRepository'
 import { StorageError } from '@supabase/storage-js'
 import { tryParseJson } from '../utils/tryParseJson'
+import { randomUUID } from 'node:crypto'
 
 const BUCKET_NAME = 'photos'
 const FOLDER_NAME = 'fotosReceitas'
@@ -88,7 +89,7 @@ export const create: RequestHandler = async (req, res, next) => {
         }
         if (files && files.length > 0) {
             for (const file of files) {
-                const fileName = `${Date.now()}-${file.originalname}`
+                const fileName = `${randomUUID()}-${Date.now()}`
                 const { error: uploadError } = await supabase.storage
                     .from(BUCKET_NAME)
                     .upload(`${FOLDER_NAME}/${fileName}`, file.buffer, {
@@ -264,7 +265,7 @@ export const update: RequestHandler = async (req, res, next) => {
                 }
             }
             for (const file of files) {
-                const fileName = `${Date.now()}-${file.originalname}`
+                const fileName = `${randomUUID()}-${Date.now()}`
                 const { error: uploadError } = await supabase.storage
                     .from(BUCKET_NAME)
                     .upload(`${FOLDER_NAME}/${fileName}`, file.buffer, {

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,11 +1,11 @@
 import { supabase } from '../db'
-import { v4 as uuidv4 } from 'uuid'
 import argon2 from 'argon2'
 import jwt from 'jsonwebtoken'
 import nodemailer from 'nodemailer'
 import type { RequestHandler } from 'express'
 import { PrismaUsuarioRepository } from '../repositories/prisma/PrismaUsuarioRepository'
 import { z } from 'zod'
+import { randomUUID } from 'node:crypto'
 
 const BUCKET_NAME = 'photos'
 const FOLDER_NAME = 'fotoPerfil'
@@ -445,7 +445,7 @@ export const resetPasswordUser: RequestHandler = async (req, res, next) => {
 
 async function uploadImage(file: Express.Multer.File) {
     try {
-        const uniqueFileName = `${uuidv4()}-${file.originalname}`
+        const uniqueFileName = `${randomUUID()}-${Date.now()}`
         const { data, error } = await supabase.storage
             .from(BUCKET_NAME)
             .upload(`${FOLDER_NAME}/${uniqueFileName}`, file.buffer, {


### PR DESCRIPTION
…usando randomUUID em vez de Date.now

## Resumo por Sourcery

Refatora a nomeação de uploads de arquivos para usar crypto.randomUUID para identificadores únicos em vez de depender unicamente de timestamps ou do pacote uuid

Melhorias:
- Substitui nomes de arquivos baseados em timestamp e o uso de uuidv4 por randomUUID e Date.now() para nomear uploads em receitaController e userController
- Remove a dependência uuid e atualiza as importações para usar randomUUID de node:crypto

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor file upload naming to use crypto.randomUUID for unique identifiers instead of relying solely on timestamps or the uuid package

Enhancements:
- Replace timestamp-based filenames and uuidv4 usage with randomUUID and Date.now() for upload naming in receitaController and userController
- Remove uuid dependency and update imports to use node:crypto’s randomUUID

</details>