### PR TITLE
consertar filename bucket

### DIFF
--- a/src/controllers/receitaController.ts
+++ b/src/controllers/receitaController.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 import { PrismaTemaRepository } from '../repositories/prisma/PrismaTemaRepository'
 import { StorageError } from '@supabase/storage-js'
 import { tryParseJson } from '../utils/tryParseJson'
+import { randomUUID } from 'node:crypto'
 
 const BUCKET_NAME = 'photos'
 const FOLDER_NAME = 'fotosReceitas'
@@ -88,7 +89,7 @@ export const create: RequestHandler = async (req, res, next) => {
         }
         if (files && files.length > 0) {
             for (const file of files) {
-                const fileName = `${Date.now()}-${file.originalname}`
+                const fileName = `${randomUUID()}-${Date.now()}`
                 const { error: uploadError } = await supabase.storage
                     .from(BUCKET_NAME)
                     .upload(`${FOLDER_NAME}/${fileName}`, file.buffer, {
@@ -264,7 +265,7 @@ export const update: RequestHandler = async (req, res, next) => {
                 }
             }
             for (const file of files) {
-                const fileName = `${Date.now()}-${file.originalname}`
+                const fileName = `${randomUUID()}-${Date.now()}`
                 const { error: uploadError } = await supabase.storage
                     .from(BUCKET_NAME)
                     .upload(`${FOLDER_NAME}/${fileName}`, file.buffer, {

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,11 +1,11 @@
 import { supabase } from '../db'
-import { v4 as uuidv4 } from 'uuid'
 import argon2 from 'argon2'
 import jwt from 'jsonwebtoken'
 import nodemailer from 'nodemailer'
 import type { RequestHandler } from 'express'
 import { PrismaUsuarioRepository } from '../repositories/prisma/PrismaUsuarioRepository'
 import { z } from 'zod'
+import { randomUUID } from 'node:crypto'
 
 const BUCKET_NAME = 'photos'
 const FOLDER_NAME = 'fotoPerfil'
@@ -445,7 +445,7 @@ export const resetPasswordUser: RequestHandler = async (req, res, next) => {
 
 async function uploadImage(file: Express.Multer.File) {
     try {
-        const uniqueFileName = `${uuidv4()}-${file.originalname}`
+        const uniqueFileName = `${randomUUID()}-${Date.now()}`
         const { data, error } = await supabase.storage
             .from(BUCKET_NAME)
             .upload(`${FOLDER_NAME}/${uniqueFileName}`, file.buffer, {


### PR DESCRIPTION
## Resumo por Sourcery

Padroniza a nomeação de uploads de arquivos usando randomUUID do Node com timestamps nos controllers de receitas e usuários, removendo referências aos nomes de arquivos originais e à biblioteca UUID externa.

Melhorias:
- Usa randomUUID de 'node:crypto' para gerar nomes de arquivos únicos para uploads de receitas
- Substitui a nomeação baseada em uuidv4 nos uploads de usuários por randomUUID e timestamp

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize file upload naming by using Node's randomUUID with timestamps across recipe and user controllers, removing references to original filenames and external UUID library.

Enhancements:
- Use randomUUID from 'node:crypto' to generate unique filenames for recipe uploads
- Replace uuidv4-based naming in user uploads with randomUUID and timestamp

</details>