### PR TITLE
Bugfix/coerce-types-users

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -41,12 +41,12 @@ const storeUserSchema = z.object({
         .string()
         .min(6, 'A senha deve ter pelo menos 6 caracteres.')
         .max(255, 'A senha deve ter no máximo 255 caracteres.'),
-    nivelConsciencia: z
+    nivelConsciencia: z.coerce
         .number()
         .min(0, 'Nível de consciência deve ser pelo menos 0.')
         .max(5, 'Nível de consciência deve ser no máximo 5.'),
-    isMonitor: z.boolean(),
-    fotoUsu: z.string().url().optional(),
+    isMonitor: z.coerce.boolean(),
+    avatar: z.string().url().optional(),
 })
 
 export const storeUser: RequestHandler = async (req, res, next) => {
@@ -175,13 +175,13 @@ const updateUserBodySchema = z.object({
         .min(6, 'A senha deve ter pelo menos 6 caracteres.')
         .max(255, 'A senha deve ter no máximo 255 caracteres.')
         .optional(),
-    nivelConsciencia: z
+    nivelConsciencia: z.coerce
         .number()
         .min(0, 'Nível de consciência deve ser pelo menos 0.')
         .max(5, 'Nível de consciência deve ser no máximo 5.')
         .optional(),
-    isMonitor: z.boolean().optional(),
-    fotoUsu: z.string().url().optional(),
+    isMonitor: z.coerce.boolean().optional(),
+    avatar: z.string().url().optional(),
 })
 
 const updateUserParamsSchema = z.object({

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -42,7 +42,7 @@ const router: Router = Router()
  *                 description: Nível de conscientização do usuário (0-5)
  *               isMonitor:
  *                 type: boolean
- *               fotoUsu:
+ *               avatar:
  *                 type: string
  *                 format: binary
  *                 description: Imagem de perfil do usuário
@@ -52,7 +52,7 @@ const router: Router = Router()
  *       400:
  *         description: Erro na criação do usuário
  */
-router.post('/usuario', userUpload.single('fotoUsu'), storeUser)
+router.post('/usuario', userUpload.single('avatar'), storeUser)
 
 /**
  * @swagger
@@ -222,7 +222,7 @@ router.get('/usuario/:id', authMiddleware, showUser)
  *               senha:
  *                 type: string
  *                 description: Nova senha do usuário, caso queira alterar
- *               fotoUsu:
+ *               avatar:
  *                 type: string
  *                 format: binary
  *                 description: Imagem de perfil do usuário
@@ -241,7 +241,7 @@ router.get('/usuario/:id', authMiddleware, showUser)
 router.put(
     '/usuario/:id',
     authMiddleware,
-    userUpload.single('fotoUsu'),
+    userUpload.single('avatar'),
     updateUser,
 )
 


### PR DESCRIPTION
## Resumo por Sourcery

Converter entradas de string para os tipos apropriados nos schemas de validação de usuário e unificar o nome do campo de imagem de perfil no código e na documentação

Correções de bugs:
- Adicionar coerção Zod para campos de número e booleano nos schemas de criação e atualização de usuário

Melhorias:
- Renomear o campo de imagem de perfil do usuário de `fotoUsu` para `avatar` em controllers, rotas e handlers de upload

Documentação:
- Atualizar as definições do Swagger e os nomes dos parâmetros para usar `avatar` em vez de `fotoUsu`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Coerce string inputs to appropriate types in user validation schemas and unify the profile image field name across code and documentation

Bug Fixes:
- Add Zod coercion for number and boolean fields in user creation and update schemas

Enhancements:
- Rename user profile image field from fotoUsu to avatar in controllers, routes, and upload handlers

Documentation:
- Update Swagger definitions and parameter names to use avatar instead of fotoUsu

</details>